### PR TITLE
Fix aircraftName crash

### DIFF
--- a/lib/model/details.js
+++ b/lib/model/details.js
@@ -92,7 +92,7 @@ Details.prototype.getAircraftSn = function() {
 }
 
 Details.prototype.getAircraftName = function() {
-  return this.buffer.toString("utf8", this.index+278, this.index+310);
+  return this.buffer.toString("utf8", this.index+278, this.index+302);
 }
 
 Details.prototype.getActiveTimestamp = function() {

--- a/lib/model/recover.js
+++ b/lib/model/recover.js
@@ -42,7 +42,7 @@ Recover.prototype.getAircraftSn = function() {
 }
 
 Recover.prototype.getAircraftName = function() {
-  return this.buffer.toString("utf8", this.index+15, this.index+47);
+  return this.buffer.toString("utf8", this.index+15, this.index+39);
 }
 
 Recover.prototype.getActiveTimestamp = function() {


### PR DESCRIPTION
AircraftName seems to be shorter.

Find attached a sample file with a collision:
[DJIFlightRecord_2015-12-05_[15-34-51].txt](https://github.com/mikeemoo/dji-log-parser/files/622144/DJIFlightRecord_2015-12-05_.15-34-51.txt)
.